### PR TITLE
Replace nanoEpoch implementation to use System.nanoTime for improved precision

### DIFF
--- a/src/main/java/com/coralblocks/coralme/util/SystemTimestamper.java
+++ b/src/main/java/com/coralblocks/coralme/util/SystemTimestamper.java
@@ -1,35 +1,30 @@
-/* 
+/*
  * Copyright 2015-2024 (c) CoralBlocks LLC - http://www.coralblocks.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
 package com.coralblocks.coralme.util;
 
 /**
- * <p>This timestamper is here just for illustrative purposes.</p>
- * 
- * <p>There are of course much better ways to get the epoch with nanosecond precision. And without producing any garbage for the GC.</p>
+ * Returns the JVM monotonic nanosecond time via {@link System#nanoTime()}.
+ *
+ * Hot-path: zero allocations, single native call and a return.
+ *
+ * Note: this is NOT epoch-based; use only where a monotonic nanosecond timestamp is acceptable.
  */
-public class SystemTimestamper implements Timestamper {
-	
-	/**
-	 * Simply returns System.currentTimeMillis * 1000000L.
-	 * Of course this is bad, so feel free to implement other better/native/garbage-free timestampers ;)
-	 * 
-	 * @return the epoch timestamp in nanoseconds
-	 */
-	@Override
-	public long nanoEpoch() {
-		return System.currentTimeMillis() * 1000000L;
-	}
+public final class SystemTimestamper implements Timestamper {
+
+    @Override
+    public long nanoEpoch() {
+        return System.nanoTime();
+    }
 }


### PR DESCRIPTION
Replaced calculation of nanoseconds with nanoEpoch implementation to use System.nanoTime for improved precision. 